### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-#APAudioPlayer
+# APAudioPlayer
 
 <img src="https://dl.dropboxusercontent.com/u/2334198/APAudioPlayer-git-teaser.png">
 
 Drop-in iOS Audio Player built on top of BASS-library. 
 
-###Supported formats:
+### Supported formats:
 
 *.m4a,
 *.mp3,


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
